### PR TITLE
adding a konsole dark theme which blends in more with system defaults

### DIFF
--- a/konsole/Konsole Dark.colors
+++ b/konsole/Konsole Dark.colors
@@ -1,6 +1,5 @@
 [WM]
 activeBackground=34,37,38
-activeForeground=237,239,233
+activeForeground=255,255,255
 inactiveBackground=39,41,44
-inactiveForeground=237,239,233
-
+inactiveForeground=255,255,255

--- a/konsole/Konsole Dark.colors
+++ b/konsole/Konsole Dark.colors
@@ -1,0 +1,6 @@
+[WM]
+activeBackground=34,37,38
+activeForeground=237,239,233
+inactiveBackground=39,41,44
+inactiveForeground=237,239,233
+


### PR DESCRIPTION
Hi @eritbh ,

I have added a new Konsole theme which blends in more with the system defaults IMO (or at least on my machine).
Active Window:
![image](https://github.com/user-attachments/assets/43d2d260-9bbf-428c-bce0-dbcd2319a5d6)

Inactive Window:
![image](https://github.com/user-attachments/assets/1a2a4a48-b79b-44f8-ae3c-72d0ff8d0a3a)

Cheers,
matezoltanfarkas
